### PR TITLE
Add two new AI bookmarks to collection

### DIFF
--- a/src/data/bookmarks.ts
+++ b/src/data/bookmarks.ts
@@ -402,6 +402,22 @@ export const bookmarks: Bookmark[] = [
     category: 'ai',
     type: 'article',
   },
+  {
+    id: 'ai-12',
+    title: 'Stanford AIMS Lab Textbook',
+    description: 'Open-access textbook from Stanford\'s AI in Medicine and Imaging Lab, covering foundational concepts and applications of AI',
+    url: 'https://aimslab.stanford.edu/textbook/',
+    category: 'ai',
+    type: 'website',
+  },
+  {
+    id: 'ai-13',
+    title: 'LLM Benchmarks: The Good, The Bad, and The Ugly',
+    description: 'Cameron R. Wolfe\'s deep dive into how LLMs are evaluated, the limitations of current benchmarks, and what it takes to meaningfully measure model quality',
+    url: 'https://cameronrwolfe.substack.com/p/llm-bench',
+    category: 'ai',
+    type: 'article',
+  },
 ];
 
 // Utility to extract domain from URL for favicon fetching


### PR DESCRIPTION
## Summary
Added two new bookmarks to the AI category in the bookmarks collection.

## Key Changes
- Added Stanford AIMS Lab Textbook (ai-12): An open-access textbook covering foundational concepts and applications of AI in medicine and imaging
- Added LLM Benchmarks article (ai-13): Cameron R. Wolfe's analysis of LLM evaluation methods, benchmark limitations, and model quality measurement

## Implementation Details
Both bookmarks follow the existing structure with unique IDs, descriptive titles, detailed descriptions, URLs, and proper categorization. The Stanford resource is categorized as a website while the LLM Benchmarks piece is categorized as an article, reflecting their respective content types.

https://claude.ai/code/session_011KZsxoFPQZjPTqVGQofvt3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new AI-related bookmarks: "Stanford AIMS Lab Textbook" (website) and "LLM Benchmarks: The Good, The Bad, and The Ugly" (article) to the bookmarks collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->